### PR TITLE
Tilføjet nyt kriterie til pawn

### DIFF
--- a/Skak/Skak/MoveRules.cs
+++ b/Skak/Skak/MoveRules.cs
@@ -26,6 +26,9 @@
                                 return true;
                             }
                             else if (CompareColors(pieceId, grid[posY - 1, posX]) == true) {
+                                return false;
+                            }
+                            else if (CompareColors(pieceId, grid[posY - 1, posX]) == false) {
                                 return true;
                             }
                             else {//error message: move cannot be made


### PR DESCRIPTION
Rettet når brikken rykker 1 fremad kan den ikke tage modstanderens brik samt kan ikke udføre rykket. Har også tilføjet mulighed for at rykke hvis ingen brik er foran.